### PR TITLE
fix: build gradle namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'com.tiendung01023.zalo_flutter'
     compileSdkVersion 34
-    
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,8 +29,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.tiendung01023.zalo_flutter'
     compileSdkVersion 34
-
+    
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Kể từ > Android Gradle Plugin 7.0.0 thì build.gradle có required namespace nên nếu không có thì khi complie bị lỗi.